### PR TITLE
Fix Uncentered Counter

### DIFF
--- a/02-counter/setup/styles.css
+++ b/02-counter/setup/styles.css
@@ -145,7 +145,7 @@ p {
     width: 95vw;
   }
 }
-main {
+body {
   min-height: 100vh;
   display: grid;
   place-items: center;


### PR DESCRIPTION
So before it was "main" which wasn't on the html, and it would cause the whole element to be in the middle on the top.
By changing it to "body", fixing the uncentered element and making it centered.